### PR TITLE
Fix typo on teleoperation

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
 						<h3>Data Collection Methods</h3>
 						Thanks to its portablity and intuitive design, UMI allows for &#9889; fast data collection at a rate of 30 seconds/demonstration.
 				        <h4>Comparison with Other Methods</h4>
-						For the cup arrangement task, UMI gripper is over 3× faster than teleportation, reaching 48% of human hand speed.
+						For the cup arrangement task, UMI gripper is over 3× faster than teleoperation, reaching 48% of human hand speed.
 						<div class="box alt" style="margin-bottom: 1em; margin-top: 1em;">
 							<div class="row 50% uniform" style="width: 100%;">
 								<div class="2u" style="font-size: 1em; line-height: 1.5em; text-align: center; width: 33.3%">


### PR DESCRIPTION
I was truly hoping for a robot that can do teleportation; unfortunately I think we'll still have to limit ourselves to teleoperation.

Edit: looking at a few more papers, it seems that the terms are used interchangeably, even if "teleportation" seems to be way less common (and I'd say a bit out of its original meaning compared to teleoperation)